### PR TITLE
Fixed ChangeCharacterEvent.hxc

### DIFF
--- a/Change Character/ChangeCharacterEvent.hxc
+++ b/Change Character/ChangeCharacterEvent.hxc
@@ -5,6 +5,7 @@ import funkin.play.character.BaseCharacter;
 import funkin.play.character.CharacterDataParser;
 import funkin.play.event.ScriptedSongEvent;
 import funkin.play.PlayState;
+import openfl.utils.Assets;
 //import Reflect;
 
 /**
@@ -68,7 +69,7 @@ class ChangeCharacterEvent extends ScriptedSongEvent {
 
 	//helper function
 	function getValue(field:String, def:Dynamic) {
-		var value = Type.resolveClass("Reflect").field(dataValue, field);
+		var value = Assets.resolveClass("Reflect").field(dataValue, field);
 		if (value == null)
 			return def;
 		else
@@ -168,6 +169,7 @@ class ChangeCharacterHandler extends Module {
 			ok = true;
 			var i = 0;
 			for(char in [PlayState.instance.currentStage.getBoyfriend(), PlayState.instance.currentStage.getDad(), PlayState.instance.currentStage.getGirlfriend()]) {
+				if (char == null) continue;
 				chars[i].set(char.characterId, char);
 				defaults[i] = char;
 				i++;
@@ -175,8 +177,8 @@ class ChangeCharacterHandler extends Module {
 			for(event in PlayState.instance.songEvents) {
 				if(event.value != null) {
 					//??????????????????
-					var char = Type.resolveClass("Reflect").field(event.value, 'char');
-					var target = Type.resolveClass("Reflect").field(event.value, 'target');
+					var char = Assets.resolveClass("Reflect").field(event.value, 'char');
+					var target = Assets.resolveClass("Reflect").field(event.value, 'target');
 					if(char != null && target != null && !chars[target].exists(char)) {
 						var hi = CharacterDataParser.fetchCharacter(char);
 						chars[strid.indexOf(target)].set(char, hi);


### PR DESCRIPTION
I added a workaround for using the `Type` class' `resolveClass` method.  Because `Type` got blacklisted by Eric, you can no longer use it directly, BUT if you look at the `openfl.utils.Assets` class, you will see that it has a method with the same name, which just uses `Type`'s method, so you can use that instead of using `Type` directly.

I also added a check for if a character is null when getting the default characters because it would raise errors for songs which remove some of the characters from the stage.

closes #1 