### PR TITLE
Fixed ChangeCharacterEvent.hxc again somehow

### DIFF
--- a/Change Character/ChangeCharacterEvent.hxc
+++ b/Change Character/ChangeCharacterEvent.hxc
@@ -50,10 +50,6 @@ class ChangeCharacterEvent extends ScriptedSongEvent {
 		];
 	}
 
-    public override function getTitle():String
-    {
-      return "Change Character (Redux, dont use this one)";
-    }
 	override function handleEvent(data) {
 		if (data.value != null) {
 			dataValue = data.value;
@@ -165,7 +161,7 @@ class ChangeCharacterHandler extends Module {
 	function hideChar(char:BaseCharacter) {
 		char.alpha = .00001;
 		char.scrollFactor.set();
-		char.x += 20000000;
+		char.screenCenter();
 		PlayState.instance.add(char);
 	}
 

--- a/Change Character/ChangeCharacterEvent.hxc
+++ b/Change Character/ChangeCharacterEvent.hxc
@@ -5,16 +5,18 @@ import funkin.play.character.BaseCharacter;
 import funkin.play.character.CharacterDataParser;
 import funkin.play.event.ScriptedSongEvent;
 import funkin.play.PlayState;
-import openfl.utils.Assets;
+import funkin.util.FunkinTypeResolver;
 //import Reflect;
 
 /**
  * @author MayoOddToSee
  */
 class ChangeCharacterEvent extends ScriptedSongEvent {
-	static var BF = 'bf'; //does static even do or mean anything lol
-	static var DAD = 'dad';
-	static var GF = 'gf';
+	var BF = 'bf';
+	var DAD = 'dad';
+	var GF = 'gf';
+
+	var typeResolver:FunkinTypeResolver = new FunkinTypeResolver();
 	
 	var dataValue:Dynamic;
 
@@ -48,6 +50,10 @@ class ChangeCharacterEvent extends ScriptedSongEvent {
 		];
 	}
 
+    public override function getTitle():String
+    {
+      return "Change Character (Redux, dont use this one)";
+    }
 	override function handleEvent(data) {
 		if (data.value != null) {
 			dataValue = data.value;
@@ -69,7 +75,7 @@ class ChangeCharacterEvent extends ScriptedSongEvent {
 
 	//helper function
 	function getValue(field:String, def:Dynamic) {
-		var value = Assets.resolveClass("Reflect").field(dataValue, field);
+		var value = typeResolver.resolveClass("Reflect").field(dataValue, field);
 		if (value == null)
 			return def;
 		else
@@ -90,6 +96,8 @@ class ChangeCharacterHandler extends Module {
 	var charsFetched:Array<String> = [];
 	var strid:Array<String> = ['bf', 'dad', 'gf'];
 	var tid:Array<CharacterType> = [CharacterType.BF, CharacterType.DAD, CharacterType.GF];
+
+	var typeResolver:FunkinTypeResolver = new FunkinTypeResolver();
 
 	public function new() {
 		super('change-character-handler');
@@ -157,7 +165,7 @@ class ChangeCharacterHandler extends Module {
 	function hideChar(char:BaseCharacter) {
 		char.alpha = .00001;
 		char.scrollFactor.set();
-		char.screenCenter();
+		char.x += 20000000;
 		PlayState.instance.add(char);
 	}
 
@@ -177,8 +185,8 @@ class ChangeCharacterHandler extends Module {
 			for(event in PlayState.instance.songEvents) {
 				if(event.value != null) {
 					//??????????????????
-					var char = Assets.resolveClass("Reflect").field(event.value, 'char');
-					var target = Assets.resolveClass("Reflect").field(event.value, 'target');
+					var char = typeResolver.resolveClass("Reflect").field(event.value, 'char');
+					var target = typeResolver.resolveClass("Reflect").field(event.value, 'target');
 					if(char != null && target != null && !chars[target].exists(char)) {
 						var hi = CharacterDataParser.fetchCharacter(char);
 						chars[strid.indexOf(target)].set(char, hi);


### PR DESCRIPTION
So the FNF devs blocked the previous workaround I used, and I thought that the only way would be to re-write this function without using `Reflect` or `resolveClass` (which I didn't plan to do), BUT THEN I FOUND ANOTHER WORKAROUND FOR USING `resolveClass` SOMEHOW?!

So apparently, they have this class in the code called `FunkinTypeResolver`, which you can create an instance of to use `resolveClass` and `resolveEnum`, and it was created to give `haxe.Unserializer` a custom type resolvers which returns `null` if the class requested is `Dynamic`. I feel like the devs will find this workaround sooner or later, so I recommend you try to write a version of this function that doesn't use `resolveClass` or `Reflect`, but for now, this workaround works on 0.5.0 just fine.

I also removed the `static` keyword from behind `BF`, `DAD`, and `GF`, because I'm pretty sure it doesn't do anything in Hscript.

Closes #3